### PR TITLE
Add config get command for retrieving API keys

### DIFF
--- a/cmd/opper/commands/builders/config_commands.go
+++ b/cmd/opper/commands/builders/config_commands.go
@@ -16,7 +16,13 @@ func BuildConfigCommands(executeCommand func(commands.Command) error) *cobra.Com
   opper config add mykey sk-xxx
 
   # Add a new API key with custom base URL
-  opper config add mykey sk-xxx --base-url https://api.custom.com`,
+  opper config add mykey sk-xxx --base-url https://api.custom.com
+
+  # Get an API key value
+  opper config get dev
+
+  # Use API key in environment variable
+  OPPER_API_KEY=$(opper config get dev) ./myapp`,
 	}
 
 	// List command
@@ -58,10 +64,24 @@ func BuildConfigCommands(executeCommand func(commands.Command) error) *cobra.Com
 		},
 	)
 
+	// Get command
+	getCmd := &cobra.Command{
+		Use:   "get <name>",
+		Short: "Get an API key value",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return executeCommand(&commands.ConfigCommand{
+				Action: "get",
+				Name:   args[0],
+			})
+		},
+	}
+
 	configCmd.AddCommand(
 		listCmd,
 		addCmd,
 		removeCmd,
+		getCmd,
 	)
 
 	return configCmd

--- a/cmd/opper/commands/config_commands.go
+++ b/cmd/opper/commands/config_commands.go
@@ -48,6 +48,16 @@ func (c *ConfigCommand) Execute(ctx context.Context, client *opperai.Client) err
 		}
 		fmt.Printf("Removed API key '%s'\n", c.Name)
 
+	case "get":
+		if c.Name == "" {
+			return fmt.Errorf("name required")
+		}
+		if apiKey, exists := cfg.APIKeys[c.Name]; exists {
+			fmt.Print(apiKey.Key)
+		} else {
+			return fmt.Errorf("API key '%s' not found", c.Name)
+		}
+
 	default:
 		return fmt.Errorf("unknown config action: %s", c.Action)
 	}


### PR DESCRIPTION
## Summary

- Adds `opper config get <name>` command to retrieve API key values from configuration
- Enables using API keys in environment variables: `OPPER_API_KEY=$(opper config get dev) ./myapp`
- Includes proper error handling for non-existent keys

## Changes

- **cmd/opper/commands/config_commands.go**: Added "get" action to config command handler
- **cmd/opper/commands/builders/config_commands.go**: Added "get" subcommand with argument validation and updated help examples

## Usage

```bash
# Get an API key value
opper config get dev

# Use in environment variable  
OPPER_API_KEY=$(opper config get dev) ./myapp

# Alternative with backticks
OPPER_API_KEY=`opper config get dev` ./myapp
```

## Testing

- [x] Successfully retrieves existing API keys
- [x] Properly handles non-existent keys with error messages
- [x] Works with command substitution for environment variables
- [x] Integrates with existing config system

## Version Notes

No version bump required - GitHub workflow handles versioning automatically on tag creation.